### PR TITLE
Add default gas price update interval

### DIFF
--- a/e2e/parity/Dockerfile
+++ b/e2e/parity/Dockerfile
@@ -1,4 +1,4 @@
-FROM parity/parity:stable
+FROM parity/parity:v1.11.11
 
 WORKDIR /stuff
 

--- a/src/services/gasPrice.js
+++ b/src/services/gasPrice.js
@@ -65,7 +65,7 @@ async function start(chainId) {
   let bridgeContract = null
   let oracleUrl = null
   let speedType = null
-  let updateInterval = null
+  let updateInterval = 600000
   if (chainId === 'home') {
     bridgeContract = homeBridge
     oracleUrl = HOME_GAS_PRICE_ORACLE_URL

--- a/src/services/gasPrice.js
+++ b/src/services/gasPrice.js
@@ -8,6 +8,7 @@ const HomeErcABI = require('../../abis/HomeBridgeErcToErc.abi')
 const ForeignErcABI = require('../../abis/ForeignBridgeErcToErc.abi')
 const logger = require('../services/logger')
 const { setIntervalAndRun } = require('../utils/utils')
+const { DEFAULT_UPDATE_INTERVAL } = require('../utils/constants')
 
 const HomeABI = isErcToErc ? HomeErcABI : HomeNativeABI
 const ForeignABI = isErcToErc ? ForeignNativeABI : ForeignErcABI
@@ -65,19 +66,19 @@ async function start(chainId) {
   let bridgeContract = null
   let oracleUrl = null
   let speedType = null
-  let updateInterval = 600000
+  let updateInterval = null
   if (chainId === 'home') {
     bridgeContract = homeBridge
     oracleUrl = HOME_GAS_PRICE_ORACLE_URL
     speedType = HOME_GAS_PRICE_SPEED_TYPE
-    updateInterval = HOME_GAS_PRICE_UPDATE_INTERVAL
+    updateInterval = HOME_GAS_PRICE_UPDATE_INTERVAL || DEFAULT_UPDATE_INTERVAL
 
     cachedGasPrice = HOME_GAS_PRICE_FALLBACK
   } else if (chainId === 'foreign') {
     bridgeContract = foreignBridge
     oracleUrl = FOREIGN_GAS_PRICE_ORACLE_URL
     speedType = FOREIGN_GAS_PRICE_SPEED_TYPE
-    updateInterval = FOREIGN_GAS_PRICE_UPDATE_INTERVAL
+    updateInterval = FOREIGN_GAS_PRICE_UPDATE_INTERVAL || DEFAULT_UPDATE_INTERVAL
 
     cachedGasPrice = FOREIGN_GAS_PRICE_FALLBACK
   } else {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,5 +6,6 @@ module.exports = {
     factor: 1.4,
     maxTimeout: 360000,
     randomize: true
-  }
+  },
+  DEFAULT_UPDATE_INTERVAL: 600000
 }

--- a/test/gasPrice.test.js
+++ b/test/gasPrice.test.js
@@ -1,6 +1,8 @@
 const sinon = require('sinon')
 const { expect } = require('chai')
+const proxyquire = require('proxyquire').noPreserveCache()
 const { fetchGasPrice } = require('../src/services/gasPrice')
+const { DEFAULT_UPDATE_INTERVAL } = require('../src/utils/constants')
 
 describe('gasPrice', () => {
   describe('fetchGasPrice', () => {
@@ -70,6 +72,70 @@ describe('gasPrice', () => {
 
       // then
       expect(gasPrice).to.equal(null)
+    })
+  })
+  describe('start', () => {
+    const utils = { setIntervalAndRun: sinon.spy() }
+    beforeEach(() => {
+      utils.setIntervalAndRun.resetHistory()
+    })
+    it('should call setIntervalAndRun with HOME_GAS_PRICE_UPDATE_INTERVAL interval value on Home', async () => {
+      // given
+      process.env.HOME_GAS_PRICE_UPDATE_INTERVAL = 15000
+      const gasPrice = proxyquire('../src/services/gasPrice', { '../utils/utils': utils })
+
+      // when
+      await gasPrice.start('home')
+
+      // then
+      expect(process.env.HOME_GAS_PRICE_UPDATE_INTERVAL).to.equal('15000')
+      expect(process.env.HOME_GAS_PRICE_UPDATE_INTERVAL).to.not.equal(
+        DEFAULT_UPDATE_INTERVAL.toString()
+      )
+      expect(utils.setIntervalAndRun.args[0][1]).to.equal(
+        process.env.HOME_GAS_PRICE_UPDATE_INTERVAL.toString()
+      )
+    })
+    it('should call setIntervalAndRun with FOREIGN_GAS_PRICE_UPDATE_INTERVAL interval value on Foreign', async () => {
+      // given
+      process.env.FOREIGN_GAS_PRICE_UPDATE_INTERVAL = 15000
+      const gasPrice = proxyquire('../src/services/gasPrice', { '../utils/utils': utils })
+
+      // when
+      await gasPrice.start('foreign')
+
+      // then
+      expect(process.env.FOREIGN_GAS_PRICE_UPDATE_INTERVAL).to.equal('15000')
+      expect(process.env.HOME_GAS_PRICE_UPDATE_INTERVAL).to.not.equal(
+        DEFAULT_UPDATE_INTERVAL.toString()
+      )
+      expect(utils.setIntervalAndRun.args[0][1]).to.equal(
+        process.env.FOREIGN_GAS_PRICE_UPDATE_INTERVAL.toString()
+      )
+    })
+    it('should call setIntervalAndRun with default interval value on Home', async () => {
+      // given
+      delete process.env.HOME_GAS_PRICE_UPDATE_INTERVAL
+      const gasPrice = proxyquire('../src/services/gasPrice', { '../utils/utils': utils })
+
+      // when
+      await gasPrice.start('home')
+
+      // then
+      expect(process.env.HOME_GAS_PRICE_UPDATE_INTERVAL).to.equal(undefined)
+      expect(utils.setIntervalAndRun.args[0][1]).to.equal(DEFAULT_UPDATE_INTERVAL)
+    })
+    it('should call setIntervalAndRun with default interval value on Foreign', async () => {
+      // given
+      delete process.env.FOREIGN_GAS_PRICE_UPDATE_INTERVAL
+      const gasPrice = proxyquire('../src/services/gasPrice', { '../utils/utils': utils })
+
+      // when
+      await gasPrice.start('foreign')
+
+      // then
+      expect(process.env.FOREIGN_GAS_PRICE_UPDATE_INTERVAL).to.equal(undefined)
+      expect(utils.setIntervalAndRun.args[0][1]).to.equal(DEFAULT_UPDATE_INTERVAL)
     })
   })
 })


### PR DESCRIPTION
Closes #83 

Adds a default value for gas price update interval to be used if the value is not defined on `.env`. I used `600000` which is the value defined on `.env.example`, let me know if you think of a better value. 