### PR TITLE
Fix issue with start block parameters

### DIFF
--- a/config/base.config.js
+++ b/config/base.config.js
@@ -1,5 +1,6 @@
 require('dotenv').config()
 
+const { toBN } = require('web3').utils
 const { web3Home, web3Foreign } = require('../src/services/web3')
 
 const homeNativeAbi = require('../abis/HomeBridgeNativeToErc.abi')
@@ -27,7 +28,7 @@ const homeConfig = {
   bridgeContractAddress: process.env.HOME_BRIDGE_ADDRESS,
   bridgeAbi: homeAbi,
   pollingInterval: process.env.HOME_POLLING_INTERVAL,
-  startBlock: process.env.HOME_START_BLOCK,
+  startBlock: toBN(process.env.HOME_START_BLOCK || 0),
   web3: web3Home
 }
 
@@ -37,7 +38,7 @@ const foreignConfig = {
   bridgeContractAddress: process.env.FOREIGN_BRIDGE_ADDRESS,
   bridgeAbi: foreignAbi,
   pollingInterval: process.env.FOREIGN_POLLING_INTERVAL,
-  startBlock: process.env.FOREIGN_START_BLOCK,
+  startBlock: toBN(process.env.FOREIGN_START_BLOCK || 0),
   web3: web3Foreign
 }
 

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -1,5 +1,6 @@
 require('dotenv').config()
 const path = require('path')
+const { toBN } = require('web3').utils
 const { connectWatcherToQueue, connection } = require('./services/amqpClient')
 const { getBlockNumber } = require('./tx/web3')
 const { redis } = require('./services/redisClient')
@@ -103,11 +104,15 @@ async function main({ sendToQueue }) {
       logger.info('All blocks already processed')
       return
     }
+
+    const fromBlock = toBN(lastProcessedBlock).add(toBN(1))
+    const toBlock = toBN(lastBlockToProcess)
+
     const events = await getEvents({
       contract: eventContract,
       event: config.event,
-      fromBlock: lastProcessedBlock + 1,
-      toBlock: lastBlockToProcess,
+      fromBlock,
+      toBlock,
       filter: config.eventFilter
     })
     logger.info(`Found ${events.length} ${config.event} events`)


### PR DESCRIPTION
Closes #87.

Note that the names `HOME_START_BLOCK` and `FOREIGN_START_BLOCK` may be misleading: they are being interpreted as "last processed", so it will actually start from `HOME_START_BLOCK + 1`.

@akolotov do you think we should fix this? We can change the variable names to better reflect what they do, or we can fix it by subtracting 1 to them when they are used as last processed block numbers.