### PR TITLE
test parameter clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,11 +269,12 @@ When running the processes, the following commands can be used to test functiona
 | `USER_ADDRESS` | An account - the current owner of coins/tokens. |
 | `USER_ADDRESS_PRIVATE_KEY` | A private key belonging to the account. |
 | `HOME_BRIDGE_ADDRESS` | Address of the bridge in the Home network to send transactions. |
-| `HOME_MIN_AMOUNT_PER_TX` | Value (in _eth_ or tokens) to be sent in one transaction for the Home network. |
+| `HOME_MIN_AMOUNT_PER_TX` | Value (in _eth_ or tokens) to be sent in one transaction for the Home network. This should match the value specified in the `poa-bridge-contracts/deploy/.env` file. The default value in that file is 500000000000000000, which is equivilant to 0.5   |
 | `FOREIGN_BRIDGE_ADDRESS` | Address of the bridge in the Foreign network to send transactions. |
-| `FOREIGN_MIN_AMOUNT_PER_TX` | Value (in _eth_ or tokens) to be sent in one transaction for the Foreign network. |
+| `FOREIGN_MIN_AMOUNT_PER_TX` | Value (in _eth_ or tokens) to be sent in one transaction for the Foreign network. This should match the value specified in the `poa-bridge-contracts/deploy.env` file. The default value in that file is 500000000000000000, which is equivilant to 0.5 |
 | `ERC20_TOKEN_ADDRESS` |  An address of the token deployed on the Home side for `ERC20-to-ERC20` mode. |
-| `BRIDGEABLE_TOKEN_ADDRESS` | An address of the token deployed on the Home side for `Native-to-ERC20` mode or on the Foreign side for `ERC20-to-ERC20`. |
+| `BRIDGEABLE_TOKEN_ADDRESS` | An address of the token deployed on the Home side for `Native-to-ERC20` mode or on the Foreign side for `ERC20-to-ERC20` (specified as erc677 in the `poa-bridge-contracts/deploy/bridgeDeploymentResults.json` file). |
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,16 @@ For more information on the Redis/RabbitMQ requirements, see [#90](/../../issues
 
 There are two options to run the nodejs oracle:
 1. Docker containers. This requires [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/) installed. If you are on Linux, it's also recommended that you [create a docker group and add your user to it](https://docs.docker.com/install/linux/linux-postinstall/), so that you can use the CLI without sudo.
-2. NodeJs Package Manager.
+2. NodeJs Package Manager (NPM).
+
+### Docker
+
+  - Start RabbitMQ and Redis: if you are running the bridge containers for the first time use `docker-compose up -d --build` otherwise use `docker-compose up -d` 
+  - `docker-compose run bridge npm run watcher:signature-request`
+  - `docker-compose run bridge npm run watcher:collected-signatures`
+  - `docker-compose run bridge npm run watcher:affirmation-request`
+  - `docker-compose run bridge npm run sender:home`
+  - `docker-compose run bridge npm run sender:foreign`
 
 ### NPM
 
@@ -151,15 +160,6 @@ There are two options to run the nodejs oracle:
   - `npm run watcher:affirmation-request`
   - `npm run sender:home`
   - `npm run sender:foreign`
-
-### Docker
-
-  - Start RabbitMQ and Redis: if you are running the bridge containers for the first time use `docker-compose up -d --build` otherwise use `docker-compose up -d` 
-  - `docker-compose run bridge npm run watcher:signature-request`
-  - `docker-compose run bridge npm run watcher:collected-signatures`
-  - `docker-compose run bridge npm run watcher:affirmation-request`
-  - `docker-compose run bridge npm run sender:home`
-  - `docker-compose run bridge npm run sender:foreign`
 
 ### Bridge UI
 
@@ -269,11 +269,11 @@ When running the processes, the following commands can be used to test functiona
 | `USER_ADDRESS` | An account - the current owner of coins/tokens. |
 | `USER_ADDRESS_PRIVATE_KEY` | A private key belonging to the account. |
 | `HOME_BRIDGE_ADDRESS` | Address of the bridge in the Home network to send transactions. |
-| `HOME_MIN_AMOUNT_PER_TX` | Value (in _eth_ or tokens) to be sent in one transaction for the Home network. This should match the value specified in the `poa-bridge-contracts/deploy/.env` file. The default value in that file is 500000000000000000, which is equivilant to 0.5   |
+| `HOME_MIN_AMOUNT_PER_TX` | Value (in _eth_ or tokens) to be sent in one transaction for the Home network. This should be greater than or equal to the value specified in the `poa-bridge-contracts/deploy/.env` file. The default value in that file is 500000000000000000, which is equivalent to 0.5. |
 | `FOREIGN_BRIDGE_ADDRESS` | Address of the bridge in the Foreign network to send transactions. |
-| `FOREIGN_MIN_AMOUNT_PER_TX` | Value (in _eth_ or tokens) to be sent in one transaction for the Foreign network. This should match the value specified in the `poa-bridge-contracts/deploy.env` file. The default value in that file is 500000000000000000, which is equivilant to 0.5 |
-| `ERC20_TOKEN_ADDRESS` |  An address of the token deployed on the Home side for `ERC20-to-ERC20` mode. |
-| `BRIDGEABLE_TOKEN_ADDRESS` | An address of the token deployed on the Home side for `Native-to-ERC20` mode or on the Foreign side for `ERC20-to-ERC20` (specified as erc677 in the `poa-bridge-contracts/deploy/bridgeDeploymentResults.json` file). |
+| `FOREIGN_MIN_AMOUNT_PER_TX` | Value (in _eth_ or tokens) to be sent in one transaction for the Foreign network. This should be greater than or equal to the value specified in the `poa-bridge-contracts/deploy/.env` file. The default value in that file is 500000000000000000, which is equivalent to 0.5. |
+| `ERC20_TOKEN_ADDRESS` |  An address of the token deployed on the Foreign side for `ERC20-to-ERC20` mode. Omit this parameter with other bridge modes. |
+| `BRIDGEABLE_TOKEN_ADDRESS` | An address of the token deployed on the Foreign side for `Native-to-ERC20` mode or on the Home side for `ERC20-to-ERC20` (specified as erc677 in the `poa-bridge-contracts/deploy/bridgeDeploymentResults.json` file). |
 
 
 ## Contributing


### PR DESCRIPTION
Added clarifying text to MIN_AMOUNT_PER_TX and BRIDGEABLE_TOKEN_ADDRESS.

Also, please confirm the Home side and Foreign side language is correct. For example, with `ERC20_to_ERC20` ,  erc677  in the bridgeDeploymentResults.json file is associated with the homeBridge, and in `NATIVE_TO_ERC20`, erc677 is associated with the foreignBridge. This seems to contradict the language in the last 2 testing points, but I'm not sure.
```
| `ERC20_TOKEN_ADDRESS` |  An address of the token deployed on the Home side for `ERC20-to-ERC20` mode. |
| `BRIDGEABLE_TOKEN_ADDRESS` | An address of the token deployed on the Home side for `Native-to-ERC20` mode or on the Foreign side for `ERC20-to-ERC20`. |	| `BRIDGEABLE_TOKEN_ADDRESS` | An address of the token deployed on the Home side for `Native-to-ERC20` mode or on the Foreign side for `ERC20-to-ERC20` (specified as erc677 in the `poa-bridge-contracts/deploy/bridgeDeploymentResults.json` file).
```