### PR TITLE
Add privateKeyToAddress script

### DIFF
--- a/scripts/privateKeyToAddress.js
+++ b/scripts/privateKeyToAddress.js
@@ -1,0 +1,23 @@
+const Web3 = require('web3')
+
+function add0xPrefix(s) {
+  if (s.indexOf('0x') === 0) {
+    return s
+  }
+  return `0x${s}`
+}
+
+function privateKeyToAddress(privateKey) {
+  return new Web3().eth.accounts.privateKeyToAccount(add0xPrefix(privateKey)).address
+}
+
+const privateKey = process.argv[2]
+
+if (!privateKey) {
+  console.error('Usage: node privateKeyToAddress.js <private-key>')
+  process.exit(1)
+}
+
+const address = privateKeyToAddress(privateKey)
+
+console.log(address)


### PR DESCRIPTION
Closes #107.

Usage:
```
$ node scripts/privateKeyToAddress.js 0xe0bc4bcabc8a919a252ffb7ae1a020fe861ad50e74ffddf9717c447524b51f8a
0xeCCD22081aF14fF8dD74AE8737443B335C885729
```

This duplicates code that was added in https://github.com/poanetwork/token-bridge/pull/85/commits/6575f0fd2cc8883f042bf2cd94d63840ad8031f0 as part of https://github.com/poanetwork/token-bridge/pull/85. After merging that PR we can simplify this script by requiring the function from the `utils` module.