### PR TITLE
Update documentation 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,4 @@ COPY package-lock.json .
 RUN npm install
 COPY . .
 CMD echo "To start a bridge process run:" \
-  "docker-compose run bridge npm run watcher:signature-request" \
-  "docker-compose run bridge npm run watcher:collected-signatures" \
-  "docker-compose run bridge npm run watcher:affirmation-request" \
-  "docker-compose run bridge npm run sender:home" \
-  "docker-compose run bridge npm run sender:foreign"
+  "VALIDATOR_ADDRESS=<validator address> VALIDATOR_ADDRESS_PRIVATE_KEY=<validator address private key> docker-compose up -d --build"

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ bash ./reset-lastBlock.sh <watcher> <block num>
 ```
 or
 ```shell
-docker-compose run bridge bash ./reset-lastBlock.sh <watcher> <block num>
+docker-compose exec bridge_affirmation bash ./reset-lastBlock.sh <watcher> <block num>
 ```
 
 where the _watcher_ could be one of:
@@ -248,9 +248,9 @@ See the [E2E README](/e2e) for instructions.
 
 When running the processes, the following commands can be used to test functionality.
 
-- To send deposits to a home contract run `node scripts/native_to_erc20/sendHome.js <tx num>` (or `docker-compose run bridge node scripts/native_to_erc20/sendHome.js <tx num>`), where `<tx num>` is how many tx will be sent out to deposit.
+- To send deposits to a home contract run `node scripts/native_to_erc20/sendHome.js <tx num>` (or `docker-compose exec bridge_affirmation node scripts/native_to_erc20/sendHome.js <tx num>`), where `<tx num>` is how many tx will be sent out to deposit.
 
-- To send withdrawals to a foreign contract run `node scripts/native_to_erc20/sendForeign.js <tx num>` (or `docker-compose run bridge node scripts/native_to_erc20/sendForeign.js <tx num>`), where `<tx num>` is how many tx will be sent out to withdraw.
+- To send withdrawals to a foreign contract run `node scripts/native_to_erc20/sendForeign.js <tx num>` (or `docker-compose exec bridge_affirmation node scripts/native_to_erc20/sendForeign.js <tx num>`), where `<tx num>` is how many tx will be sent out to withdraw.
 
 ### ERC20-to-ERC20 Mode Testing
 


### PR DESCRIPTION
Related to #119.
While deploying the bridge for xDAI network we have found that some documentation definitely need to be updated.
- [x] `docker-compose run` were replaced with `docker-compose exec` to avoid duplicating services. Exec will run command in the service that is already up.
- [x] `bridge` service replaced to `bridge_affirmation`. Bridge service itself doesn't have common networks with `rabbit` and `redis` and becomes useless to launch scripts at. We can use any other containers instead. For example - `bridge_affirmation`.