### PR TITLE
Update README with details about redis and rabbit volume in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,12 @@ There are two options to run the TokenBridge processes:
 
 All [watcher](#watcher) & [sender](#sender) services launch when `docker-compose` is called. 
 
+Redis and RabbitMQ data are placed in `~/bridge_data` directory.
+In case you need to reset your bridge or setup a new one (with different configuration) you must delete this directory to prevent old data from being read.
+
 **Note**: To view the Docker logs:
 * `chdir` to the directory containing the `docker-compose.yml` file used to run the bridge instance
 * [View the logs](https://docs.docker.com/v17.09/compose/reference/logs/) : `docker-compose logs`
-
-**Note 2**: 
-Redis and RabbitMQ data are placed in `~/bridge_data` directory.
-In case you need to reset your bridge or setup a new one (with different configuration) you must delete this directory to prevent old data from being read.
 
 ### NPM
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ All [watcher](#watcher) & [sender](#sender) services launch when `docker-compose
 * `chdir` to the directory containing the `docker-compose.yml` file used to run the bridge instance
 * [View the logs](https://docs.docker.com/v17.09/compose/reference/logs/) : `docker-compose logs`
 
+**Note 2**: 
+Redis and RabbitMQ data are placed in `~/bridge_data` directory.
+In case you need to reset your bridge or setup a new one (with different configuration) you must delete this directory to prevent old data from being read.
 
 ### NPM
 


### PR DESCRIPTION
Maybe I'm dumb but I lost one week due to the fact I haven't checked Redis and RabbitMQ data were stored in a volume outside docker.
I setup many different bridges but my transactions were never mined. Finally I figured out the problem was that every time my docker machine was reading the same old nonce from old redis data.

I just updated README.md with this information because I think it could be useful for someone else.
Because of this I haven't opened a new feature branch.